### PR TITLE
change match generation algo for display. fixes issue #11

### DIFF
--- a/application.js
+++ b/application.js
@@ -1,28 +1,26 @@
 (function() {
-  var $, App, Expression, Results, TestStrings,
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; },
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
-
+  var $, App, Expression, Results, TestStrings;
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   $ = jQuery;
-
-  Expression = (function(_super) {
-
-    __extends(Expression, _super);
-
+  Expression = (function() {
+    __extends(Expression, Spine.Controller);
     function Expression() {
       Expression.__super__.constructor.apply(this, arguments);
     }
-
     Expression.prototype.elements = {
       'input[name=expression]': 'regexp',
       'input[name=option]': 'option'
     };
-
     Expression.prototype.events = {
       'keyup input': 'onKeyPress'
     };
-
     Expression.prototype.onKeyPress = function(event) {
       try {
         this.value = this.buildRegex(this.regexp.val(), this.option.val());
@@ -31,54 +29,38 @@
       }
       return this.trigger('update');
     };
-
     Expression.prototype.buildRegex = function(value, option) {
       return new RegExp(value, option);
     };
-
     Expression.prototype.asUrlPart = function() {
       return encodeURIComponent(this.regexp.val() + "||||" + this.option.val());
     };
-
     return Expression;
-
-  })(Spine.Controller);
-
-  TestStrings = (function(_super) {
-
-    __extends(TestStrings, _super);
-
+  })();
+  TestStrings = (function() {
+    __extends(TestStrings, Spine.Controller);
     function TestStrings() {
       TestStrings.__super__.constructor.apply(this, arguments);
     }
-
     TestStrings.prototype.elements = {
       'textarea': 'input'
     };
-
     TestStrings.prototype.events = {
       'keyup textarea': 'onKeyPress'
     };
-
     TestStrings.prototype.onKeyPress = function(event) {
       this.getValues(this.input.val());
       return this.trigger('update');
     };
-
     TestStrings.prototype.getValues = function(val) {
       return this.values = val.split('\n');
     };
-
     TestStrings.prototype.asUrlPart = function() {
       return encodeURIComponent(JSON.stringify(this.values));
     };
-
     return TestStrings;
-
-  })(Spine.Controller);
-
+  })();
   Results = (function() {
-
     function Results(expression, test_strings) {
       this.expression = expression;
       this.test_strings = test_strings;
@@ -86,7 +68,6 @@
       this.expression.bind('update', this.compile);
       this.test_strings.bind('update', this.compile);
     }
-
     Results.prototype.compile = function() {
       var count, matches, value, _i, _len, _ref;
       $('ul#results').empty();
@@ -116,22 +97,25 @@
         return this.showError();
       }
     };
-
     Results.prototype.addShareLink = function(expression_url, test_strings_url) {
       var url;
       url = window.location.protocol + "//" + window.location.host;
       url += "/#" + expression_url + encodeURIComponent("||||") + test_strings_url;
       return $("#share_link").attr("href", url);
     };
-
     Results.prototype.matchResults = function(value, matches) {
       var index, length, match, string, _i, _len;
-      if (!matches) return;
+      if (!matches) {
+        return;
+      }
       string = '';
+      matches = this.generateMatches(value, this.expression.value);
       for (_i = 0, _len = matches.length; _i < _len; _i++) {
         match = matches[_i];
-        if (value === '') break;
-        index = value.indexOf(match);
+        if (value === '') {
+          break;
+        }
+        index = match.index;
         length = match.length;
         if (index > -1) {
           string += value.slice(0, index);
@@ -144,59 +128,73 @@
       string += value;
       return this.drawResult(string);
     };
-
+    Results.prototype.generateMatches = function(value, regex) {
+      var execution, index, length, result;
+      result = [];
+      while (execution = regex.exec(value)) {
+        index = execution.index;
+        length = execution[0].length;
+        result.push({
+          index: index,
+          length: length
+        });
+        value = value.substr(length + index);
+      }
+      return result;
+    };
     Results.prototype.drawResult = function(string) {
       return $('ul#results').append("<li>" + string + "</li>");
     };
-
     Results.prototype.matchGroups = function(value, matches, count) {
-      var match, _i, _j, _len, _len2, _ref;
-      if (!matches) return;
+      var match, _i, _j, _len, _len2, _ref, _results, _results2;
+      if (!matches) {
+        return;
+      }
       $('ul#groups').append("<li id='match_" + count + "'><h3>Match " + count + "</h3><ol></ol></li>");
       if (this.expression.option.val() === 'g') {
+        _results = [];
         for (_i = 0, _len = matches.length; _i < _len; _i++) {
           match = matches[_i];
-          if (match === '') return;
-          this.drawGroup(count, match);
+          if (match === '') {
+            return;
+          }
+          _results.push(this.drawGroup(count, match));
         }
+        return _results;
       } else {
         _ref = matches.slice(1);
+        _results2 = [];
         for (_j = 0, _len2 = _ref.length; _j < _len2; _j++) {
           match = _ref[_j];
-          if (match === '') return;
-          this.drawGroup(count, match);
+          if (match === '') {
+            return;
+          }
+          _results2.push(this.drawGroup(count, match));
         }
+        return _results2;
       }
     };
-
     Results.prototype.drawGroup = function(count, match) {
       return $("ul#groups li#match_" + count + " ol").append("<li>" + match + "</li>");
     };
-
     Results.prototype.showIntro = function() {
       $('#error').hide();
       $('#output').hide();
       return $('#intro').show();
     };
-
     Results.prototype.showError = function() {
       $('#intro').hide();
       $('#output').hide();
       return $('#error').show();
     };
-
     Results.prototype.showOutput = function() {
       $('#intro').hide();
       $('#error').hide();
       return $('#output').show();
     };
-
     return Results;
-
   })();
-
   App = (function() {
-
     function App() {
       this.load = __bind(this.load, this);
       this.loadExample = __bind(this.loadExample, this);
@@ -208,16 +206,16 @@
       });
       this.results = new Results(this.expression, this.test_strings);
       $('#example').bind('click', this.loadExample);
-      if (window.location.hash !== '') this.loadFromHash();
+      if (window.location.hash !== '') {
+        this.loadFromHash();
+      }
     }
-
     App.prototype.loadFromHash = function() {
       var option, regex, test_strings_from_url, _ref;
       _ref = decodeURIComponent(window.location.hash.substr(1)).split("||||"), regex = _ref[0], option = _ref[1], test_strings_from_url = _ref[2];
       test_strings_from_url = JSON.parse(test_strings_from_url);
       return this.load(regex, option, test_strings_from_url);
     };
-
     App.prototype.loadExample = function(event) {
       var option, regex, test_strings;
       event.preventDefault();
@@ -226,7 +224,6 @@
       test_strings = ['https://github.com/jonmagic/scriptular', 'http://scriptular.com', 'http://www.google.com', 'http://www.guardian.co.uk'];
       return this.load(regex, option, test_strings);
     };
-
     App.prototype.load = function(regex, option, test_strings) {
       $('input[name=expression]').val(regex);
       $('input[name=option]').val(option);
@@ -235,13 +232,8 @@
       this.test_strings.onKeyPress();
       return this.results.compile;
     };
-
     return App;
-
   })();
-
   window.App = App;
-
   window.$ = $;
-
 }).call(this);

--- a/scripts/application.coffee
+++ b/scripts/application.coffee
@@ -76,12 +76,13 @@ class Results
     return unless matches
     string = ''
 
+    matches = @generateMatches(value,@expression.value);
     for match in matches
       break if value == ''
 
       # console.log("This is the match: #{match}")
 
-      index = value.indexOf(match)
+      index =  match.index
       length = match.length
       if index > -1
         string += value.slice(0, index)
@@ -96,6 +97,15 @@ class Results
     string += value
 
     @drawResult string
+
+  generateMatches: (value, regex) ->
+    result = []
+    while execution = regex.exec(value) 
+        index = execution.index
+        length = execution[0].length
+        result.push({index:index,length:length})
+        value = value.substr(length+index)
+    result
 
   drawResult: (string) ->
     $('ul#results').append("<li>#{string}</li>")

--- a/spec/ResultsSpec.coffee
+++ b/spec/ResultsSpec.coffee
@@ -8,6 +8,8 @@ describe 'Results', ->
 
   subjects = [
     {'regex': 'a', 'test_strings': [{'string': 'a'}], 'output': '<span>a</span>'}
+    {'regex': 'a$', 'test_strings': [{'string': 'asdfja'}], 'output': 'asdfj<span>a</span>'}
+    {'regex': '"$', 'test_strings': [{'string': '"hello"'}], 'output': '"hello<span>"</span>'}
     {'regex': 'a(.*)c', 'test_strings': [{'string': 'abcdd', 'matches': ['b']}], 'output': '<span>abc</span>dd'}
     {'regex': 'f(oo)', 'test_strings': [{'string': 'foodbar', 'matches': ['oo']}], 'output': '<span>foo</span>dbar'}
     {

--- a/spec/ResultsSpec.js
+++ b/spec/ResultsSpec.js
@@ -1,5 +1,4 @@
 (function() {
-
   describe('Results', function() {
     var i, subject, subjects, _fn, _i, _len, _len2, _results;
     beforeEach(function() {
@@ -18,6 +17,22 @@
           }
         ],
         'output': '<span>a</span>'
+      }, {
+        'regex': 'a$',
+        'test_strings': [
+          {
+            'string': 'asdfja'
+          }
+        ],
+        'output': 'asdfj<span>a</span>'
+      }, {
+        'regex': '"$',
+        'test_strings': [
+          {
+            'string': '"hello"'
+          }
+        ],
+        'output': '"hello<span>"</span>'
       }, {
         'regex': 'a(.*)c',
         'test_strings': [
@@ -100,25 +115,33 @@
       subject = subjects[_i];
       _results.push((function(subject) {
         return it("subject " + subject['regex'] + " returns correct groups", function() {
-          var i, match, test, _j, _len3, _len4, _ref, _ref2;
+          var i, match, test, _j, _len3, _ref, _results2;
           _ref = subject['test_strings'];
+          _results2 = [];
           for (_j = 0, _len3 = _ref.length; _j < _len3; _j++) {
             test = _ref[_j];
-            if (!test['matches']) return true;
+            if (!test['matches']) {
+              return true;
+            }
             this.app.expression.value = this.app.expression.buildRegex(subject['regex'], subject['option']);
             this.app.test_strings.values = [test['string']];
             this.app.results.compile();
             expect($('ul#groups ol li').length).toBe(test['matches'].length);
-            _ref2 = test['matches'];
-            for (i = 0, _len4 = _ref2.length; i < _len4; i++) {
-              match = _ref2[i];
-              expect($($('ul#groups ol li')[i]).text()).toEqual(match);
-            }
+            _results2.push((function() {
+              var _len4, _ref2, _results3;
+              _ref2 = test['matches'];
+              _results3 = [];
+              for (i = 0, _len4 = _ref2.length; i < _len4; i++) {
+                match = _ref2[i];
+                _results3.push(expect($($('ul#groups ol li')[i]).text()).toEqual(match));
+              }
+              return _results3;
+            })());
           }
+          return _results2;
         });
       })(subject));
     }
     return _results;
   });
-
 }).call(this);


### PR DESCRIPTION
Because, at least in my opinion, the javascript implementation of match and search are really odd, the only way that I could find to get both the match and it's exact location in the string, is by using this algorithm. It can be seen in lines 100-109 of application.coffee in my new commit.

The indexOf method, that was used originally, breaks in two additional test cases that I added.  This is because indexOf can't take into account where exactly the match was found in the test string.
