### PR TITLE
Adds monospaced font to expression input

### DIFF
--- a/application.css
+++ b/application.css
@@ -215,6 +215,11 @@ input, textarea, #results, #groups {
   width: 50px;
 }
 
+#expression input[name=expression],
+#expression input[name=option] {
+  font-family: menlo, courier, sans-serif;
+}
+
 #test_strings textarea {
   height: 95px;
   width: 100%;


### PR DESCRIPTION
Hello,

First, thanks for creating Scriptular!

I was having a hard time visually parsing characters in the expression input, so I ended up changing the typeface to a mono-spaced one, Menlo. I'm currently using my own css extension to change it so I thought I would push the changes here in case you would like to add them in.

After:
![after-local](https://f.cloud.github.com/assets/1445367/353462/44146ba8-a082-11e2-817d-d3f1161d82b5.png)

Before:
![before-web](https://f.cloud.github.com/assets/1445367/353466/5390d13e-a082-11e2-9ebb-9b4df44248cf.png)
