### PR TITLE
More readable results

### DIFF
--- a/application.css
+++ b/application.css
@@ -245,7 +245,8 @@ input, textarea, #results, #groups {
 }
 
 #results span {
-  background-color: #f4ff80;
+  background-color: #9CE39E;
+  margin: 3px;
 }
 
 #groups {


### PR DESCRIPTION
It was hard to see where the yellow highlighting of match results began and ended, so I changed the color and added a small margin to the inline results.

In cramped text, the small margin makes the result more clear. I chose green because of green's association with success, and selected a green that keeps the text readable while easily differentiated from the surrounding white background.

Before: 
![screen shot 2013-10-25 at 1 50 53 pm](https://f.cloud.github.com/assets/1887182/1410061/44f93238-3d9e-11e3-837f-33280cb86dad.png)

After:
![screen shot 2013-10-25 at 1 49 18 pm](https://f.cloud.github.com/assets/1887182/1410064/49212cbc-3d9e-11e3-90b7-5371677a228e.png)
