### PR TITLE
fixed cake commands for windows environment

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,5 +1,5 @@
 {print} = require 'util'
-{spawn} = require 'child_process'
+{spawn} = require './spawn'
 
 build = (callback) ->
   coffee = spawn 'coffee', ['-c', '-o', './', 'scripts']

--- a/spawn.coffee
+++ b/spawn.coffee
@@ -1,0 +1,18 @@
+(->
+  self = this
+  spawn = undefined
+  windowsSpawn = undefined
+  spawn = require('child_process').spawn
+
+  windowsSpawn = (executable, args, options) ->
+    spawn process.env.comspec or 'cmd.exe', [
+      '/c'
+      executable
+    ].concat(args), options
+
+  if process.platform == 'win32'
+    exports.spawn = windowsSpawn
+  else
+    exports.spawn = spawn
+  return
+).call this


### PR DESCRIPTION
Call spawn of script files on windows environment causes ENOENT error appearance. This solution uses  spawn itself on Linux/Unix system and creates wrapper for this one on windows environment.