### PR TITLE
Optimize font loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Scriptular - Javascript Regular Expression Editor</title>
   <link rel="stylesheet" type="text/css" href="application.css">
-  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie&text=Scriptular" rel="stylesheet">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
   <script src="spine.js" type="text/javascript"></script>
   <script src="application.js" type="text/javascript"></script>


### PR DESCRIPTION
I've added a `text` query parameter to the Google Font request, as described [in their documentation](https://fonts.googleblog.com/2011/04/streamline-your-web-font-requests.html) that means only the characters in "Scriptular" will be downloaded, since these are the only ones styled with the font.

This reduces size of the font downloaded by 24kB.

<figure>
<figcaption>Before: &asymp;28.5kB</figcaption>

![before](https://user-images.githubusercontent.com/8526031/27540613-af70e142-5a78-11e7-972d-e8cfc19192aa.png)
</figure>

<figure>
<figcaption>After: &asymp;3.4kB</figcaption>

![after](https://user-images.githubusercontent.com/8526031/27540614-b083f006-5a78-11e7-97a5-3b1c42b7f2a0.png)
</figure>