### PR TITLE
HTML tidy up

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-us" dir="ltr">
 <head>
   <title>Scriptular - Javascript Regular Expression Editor</title>
-  <link rel="stylesheet" type="text/css" href="application.css">
+  <link href="application.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie&text=Scriptular" rel="stylesheet">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
-  <script src="spine.js" type="text/javascript"></script>
-  <script src="application.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+  <script src="spine.js"></script>
+  <script src="application.js"></script>
   <script>
     $(function() {
       new App();
@@ -31,11 +31,11 @@
       </div>
 
       <div id="intro">
-        <p>Scriptular is a javascript regular expression editor. Inspired by <a href="http://rubular.com" target="_blank">Rubular</a> it gives you a simple way to test javascript regular expressions as you write them.</p>
+        <p>Scriptular is a javascript regular expression editor. Inspired by <a href="http://rubular.com" target="_blank" rel="noopener">Rubular</a> it gives you a simple way to test javascript regular expressions as you write them.</p>
 
         <p>Start by entering a regular expression and then a test string. Or give this <a href="#" id="example">example a try</a>.</p>
 
-        <p><a href="https://developer.mozilla.org/en/JavaScript/Guide/Regular_Expressions" target="_blank">Learn more</a> about regular expressions in javascript.</p>
+        <p><a href="https://developer.mozilla.org/en/JavaScript/Guide/Regular_Expressions" target="_blank" rel="noopener">Learn more</a> about regular expressions in javascript.</p>
       </div>
 
       <div id="error">
@@ -188,19 +188,18 @@
     </div>
 
     <div id="footer">
-      <p>Created by <a href="http://theprogrammingbutler.com">Hoyt</a> and maintained by <a href="https://github.com/jonmagic/scriptular#contributors">many</a>. To contribute or report an issue visit <a href="https://github.com/jonmagic/scriptular">the project on GitHub</a>.</p>
+      <p>Created by <a href="http://theprogrammingbutler.com" rel="noopener">Hoyt</a> and maintained by <a href="https://github.com/jonmagic/scriptular#contributors" rel="noopener">many</a>. To contribute or report an issue visit <a href="https://github.com/jonmagic/scriptular" rel="noopener">the project on GitHub</a>.</p>
     </div>
   </div>
 
-  <script type="text/javascript">
+  <script>
     var _gauges = _gauges || [];
     (function() {
       var t   = document.createElement('script');
-      t.type  = 'text/javascript';
       t.async = true;
       t.id    = 'gauges-tracker';
       t.setAttribute('data-site-id', '4f542216cb25bc2358000006');
-      t.src = '//secure.gaug.es/track.js';
+      t.src = 'https://secure.gaug.es/track.js';
       var s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(t, s);
     })();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Scriptular - Javascript Regular Expression Editor</title>
   <link rel="stylesheet" type="text/css" href="application.css">
-  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie&text=Scriptular" rel="stylesheet">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
   <script src="spine.js" type="text/javascript"></script>
   <script src="application.js" type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <div id="main">
       <div id="expression">
         <h2>Regular Expression:</h2>
-        /<input name="expression" />/<input name="option" />
+        /<input name="expression">/<input name="option">
       </div>
 
       <div id="test_strings">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us" dir="ltr">
+<html lang="en-US" dir="ltr">
 <head>
   <title>Scriptular - Javascript Regular Expression Editor</title>
   <link href="application.css" rel="stylesheet">


### PR DESCRIPTION
I merged in #41 to this branch.

I've removed the `type` attributes from the script and style attributes, since in HTML5 these are not needed.

- [WHATWG `link` `type` attribute description](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-type)
- [MDN reference for `<script>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type)

I made the tracking script injector specifically use HTTPS rather than be protocol-relative.

I added `noopener` to the anchors to other domains, for the [security](https://mathiasbynens.github.io/rel-noopener/) as well as [performance](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/) benefits.

I added the US English specifier to the `html` tag, so it is explicitly declared, as [recommended by the WHATWG HTML spec](https://html.spec.whatwg.org/multipage/semantics.html#the-html-element:attr-lang).