### PR TITLE
Externalize tracking script

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     });
   </script>
 
+  <script src="https://secure.gaug.es/track.js" async id="gauges-tracker" data-site-id="4f542216cb25bc2358000006"></script>
+
   <link rel="apple-touch-icon" sizes="57x57" href="icons/apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="icons/apple-icon-60x60.png">
   <link rel="apple-touch-icon" sizes="72x72" href="icons/apple-icon-72x72.png">
@@ -209,18 +211,5 @@
       <p>Created by <a href="http://theprogrammingbutler.com" rel="noopener">Hoyt</a> and maintained by <a href="https://github.com/jonmagic/scriptular#contributors" rel="noopener">many</a>. To contribute or report an issue visit <a href="https://github.com/jonmagic/scriptular" rel="noopener">the project on GitHub</a>.</p>
     </div>
   </div>
-
-  <script>
-    var _gauges = _gauges || [];
-    (function() {
-      var t   = document.createElement('script');
-      t.async = true;
-      t.id    = 'gauges-tracker';
-      t.setAttribute('data-site-id', '4f542216cb25bc2358000006');
-      t.src = 'https://secure.gaug.es/track.js';
-      var s = document.getElementsByTagName('script')[0];
-      s.parentNode.insertBefore(t, s);
-    })();
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en-US" dir="ltr">
 <head>
   <title>Scriptular - Javascript Regular Expression Editor</title>
+  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie&amp;text=Scriptular" rel="stylesheet">
   <link href="application.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Reenie+Beanie&text=Scriptular" rel="stylesheet">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <script src="spine.js"></script>
   <script src="application.js"></script>


### PR DESCRIPTION
I have moved the Google Fonts URL to before the stylesheet, since it it loads the font that is then used in the stylesheet.

I have build the script tag that the previous inline script was building, so now there is no need for it to execute in order to construct the same tag.

![the tracking script being downloaded](https://user-images.githubusercontent.com/8526031/36227640-9597e24e-11c9-11e8-8e3d-a12813518528.png)
