### PR TITLE
Add documentation for the 3 other RegExp flags

### DIFF
--- a/application.css
+++ b/application.css
@@ -172,6 +172,7 @@ a:hover {
   margin-bottom: 20px;
 }
 
+#quick_reference th,
 #quick_reference td {
   padding-right: 15px;
   line-height:1.5em;
@@ -183,12 +184,6 @@ a:hover {
   padding-right: 5px;
   text-align: center;
   width:60px;
-}
-
-#quick_reference a {
-  position: absolute;
-  top: 20px;
-  right: 20px;
 }
 
 input, textarea, #results, #groups {
@@ -273,10 +268,6 @@ input, textarea, #results, #groups {
   list-style-type: decimal;
   margin-bottom: 10px;
   padding-left: 30px;
-}
-
-#shares li {
-
 }
 
 #shares a {

--- a/index.html
+++ b/index.html
@@ -73,16 +73,33 @@
     </div>
 
     <div id="quick_reference">
-      <div class="scrollable">
-        <h2>Modifiers:</h2>
+      <div class="scrollable">        
         <table>
+          <caption><h2>Flags:</h2></caption>
           <tr>
-            <td class="regex">i</td>
+            <th class="regex">g</th>
+            <td>Perform a global match</td>
+          </tr>
+          <tr>
+            <th class="regex">i</th>
             <td>Perform case-insensitive matching</td>
           </tr>
           <tr>
-            <td class="regex">g</td>
-            <td>Perform a global match</td>
+            <th class="regex">m</th>
+            <td>Treat beginning and end characters (^ and $) as working over multiple lines</td>
+          </tr>
+          <tr>
+            <th class="regex">u</th>
+            <td>
+              Treat the pattern as a series of Unicode code points
+              (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Regular_expression_and_Unicode_characters" rel="external noopener">
+                  See the MDN docs
+                </a>)
+            </td>
+          </tr>
+          <tr>
+            <th class="regex">y</th>
+            <td>Sticky; treat the pattern after a match as a separate pattern</td>
           </tr>
         </table>
         <h2>Brackets:</h2>


### PR DESCRIPTION
## Add the remaining flags
[All modern browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Browser_compatibility) support 5 RegExp flags so I have added documentation for them.
The flags are [described on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters)

* `m`: the multiline flag. Means that `^` and `$` match per line, rather than the whole string.
* `u`: the Unicode flag. Means that Unicode characters can be used in the pattern using `\uhhhh` syntax, where `hhhh` is the Unicode value in hexadecimal
* `y`: the sticky flag. Means that repeated matches on the same pattern will start from after the current match.

All of these flags already work in the current application, from the way that it pulls in the input.

I have slightly refactored the Flags table, while preserving the current style.

![The Flags table, styled as previously](https://user-images.githubusercontent.com/8526031/36227529-38228a7e-11c9-11e8-8d55-37525ce1d38d.png)

This PR resolves #35.