### PR TITLE
Create an npm package for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2011 Jonathan Hoyt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ So I created [Scriptular](http://scriptular.com) and started regular expressing 
 
 ## Compiling Coffeescript in Development
 
-* clone the repo
-* npm install -g coffee-script
-* cake build
+1. clone the repo
+2. npm install
+3. npm run build
 
 ## Running Tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "scriptular",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "scriptular",
+  "version": "1.0.0",
+  "description": "A rubular.com clone for JavaScript regular expressions",
+  "main": "application.js",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Open SpecRunner.html in a browser to run tests\" && exit 0",
+    "build": "cake build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonmagic/scriptular.git"
+  },
+  "keywords": [
+    "regexp",
+    "front-end"
+  ],
+  "contributors": [
+    "Jonathan Hoyt (https://github.com/jonmagic)",
+    "Brandon Keepers (https://github.com/bkeepers)",
+    "Aaron Kalin (https://github.com/martinisoft)",
+    "Ben Truyman (https://github.com/bentruyman)",
+    "John K. Paul (https://github.com/johnkpaul)",
+    "Adam Brodzinski (https://github.com/AdamBrodzinski)",
+    "brycecr (https://github.com/brycecr)",
+    "Judith Hendeveld (https://github.com/judith)",
+    "beechnut (https://github.com/beechnut)",
+    "Blair Anderson (https://github.com/blairanderson)",
+    "Vladimir Pestov (https://github.com/KozzyKoder)",
+    "Corey Leveen (https://github.com/coreyleveen)",
+    "Daniel Arthur Gallagher (https://github.com/DanArthurGallagher)",
+    "Mosh Feu (https://github.com/moshfeu)"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jonmagic/scriptular/issues"
+  },
+  "homepage": "https://github.com/jonmagic/scriptular#readme",
+  "devDependencies": {
+    "coffeescript": "1.12.7"
+  }
+}


### PR DESCRIPTION
I thought that an npm package seemed like a fair way to develop this site locally.
The CoffeeScript dependency can be managed, installed and run using the `package.json` and npm itself.

I have marked the package as `{"private": true}` so it cannot be published.

I have replicated the contributor list from the README in the `package.json`.

I have used `coffeescript@1.12.7`, which is what the code was most recently transpiled with.

I have added a licence file, copying the text from the readme (which was the MIT license).

I have copied the contributor list from the README into the `package.json`.