### PR TITLE
Correct flag validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <div id="main">
       <div id="expression">
         <h2>Regular Expression:</h2>
-        /<input name="expression">/<input name="option" type="text" pattern="gimuy" spellcheck="false" autocomplete="off" title="Set any flags you want to apply to your expression">
+        /<input name="expression">/<input name="option" type="text" pattern="(g|i|m|u|y){0,5}" spellcheck="false" autocomplete="off" title="Set any flags you want to apply to your expression">
       </div>
 
       <div id="test_strings">

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <div id="main">
       <div id="expression">
         <h2>Regular Expression:</h2>
-        /<input name="expression">/<input name="option" type="text" pattern="(g|i|m|u|y){0,5}" spellcheck="false" autocomplete="off" title="Set any flags you want to apply to your expression">
+        /<input name="expression">/<input name="option" type="text" pattern="(g|i|m|u|y)*" spellcheck="false" autocomplete="off" title="Set any flags you want to apply to your expression">
       </div>
 
       <div id="test_strings">


### PR DESCRIPTION
I updated the RegExp flag added by #46 and actually tested it with different inputs, and now it is more permissive and more correct than previously.

I have no idea how I wrote such a naïve expression for a RegExp-building website 😰 

So, now the field will reject any invalid flag letters, but it doesn't enforce that each flag can only occur once. JavaScript RegExps don't have look-behind functionality yet in order to do that.

This should be enough to resolve #49.