### PR TITLE
updated quick reference text [A-Za-z]

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
             <td>Match any character except a, b, or c</td>
           </tr>
           <tr>
-            <td class="regex">[A-z]</td>
+            <td class="regex">[A-Za-z]</td>
             <td>Match any character from uppercase A to lowercase z</td>
           </tr>
           <tr>


### PR DESCRIPTION
Hi there.

I've updated the quick reference text character class example for matching uppercase and lowercase alphabetic characters. The example changed from `[A-z]` (which also matches 6 non-alphabetic characters) to `[A-Za-z]`.

Thanks for considering this change.

Wendy